### PR TITLE
[#1] Implement GET /v1/agents/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ An OpenClaw plugin that exposes `GET /v1/agents/status` — a live status endpoi
 
 Use this to monitor your agent team remotely from anywhere: phone, terminal, ClawTalk, or any HTTP client.
 
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/agents/status` | All configured agents |
+| `GET` | `/v1/agents/status/:agentId` | Single agent by ID |
+
+Both endpoints require a gateway Bearer token.
+
 ## Response format
+
+### All agents (`GET /v1/agents/status`)
 
 ```json
 {
@@ -19,16 +30,16 @@ Use this to monitor your agent team remotely from anywhere: phone, terminal, Cla
       "current_task": "Reviewing PR #45"
     },
     {
-      "id": "max",
-      "name": "Max",
+      "id": "main",
+      "name": "Main",
       "status": "idle",
       "last_active": "2026-03-18T02:15:00.000Z",
       "last_active_ago_seconds": 780,
       "current_task": null
     },
     {
-      "id": "clive",
-      "name": "Clive",
+      "id": "alex",
+      "name": "Alex",
       "status": "stale",
       "last_active": "2026-03-18T01:00:00.000Z",
       "last_active_ago_seconds": 5400,
@@ -38,10 +49,43 @@ Use this to monitor your agent team remotely from anywhere: phone, terminal, Cla
 }
 ```
 
-**Status values:**
-- `active` — last message within 5 minutes
-- `idle` — last message within 30 minutes
-- `stale` — no activity for >30 minutes
+### Single agent (`GET /v1/agents/status/elysse`)
+
+Returns the same object shape as a single entry (not wrapped in a list):
+
+```json
+{
+  "id": "elysse",
+  "name": "Elysse",
+  "status": "active",
+  "last_active": "2026-03-18T02:30:00.000Z",
+  "last_active_ago_seconds": 120,
+  "current_task": "Reviewing PR #45"
+}
+```
+
+Returns `404` if the agent ID is not found.
+
+## Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Agent identifier |
+| `name` | string | Display name (from `identity.name`, `name`, or capitalized `id`) |
+| `status` | `"active"` \| `"idle"` \| `"stale"` | Activity status |
+| `last_active` | ISO 8601 string \| `null` | Timestamp of last session activity |
+| `last_active_ago_seconds` | number \| `null` | Seconds since last activity |
+| `current_task` | string \| `null` | Last assistant reply snippet (≤100 chars), or `null` |
+
+## Status thresholds
+
+| Status | Default | Meaning |
+|--------|---------|---------|
+| `active` | < 5 min | Recently active |
+| `idle` | 5–30 min | No recent activity |
+| `stale` | > 30 min | Inactive or never used |
+
+Thresholds are configurable — see [Configuration](#configuration).
 
 ## Installation
 
@@ -52,24 +96,68 @@ cp openclaw.plugin.json ~/.openclaw/extensions/agent-status/
 ```
 
 Add to `openclaw.json`:
+
 ```json
-"plugins": {
-  "allow": ["agent-status"],
-  "entries": { "agent-status": { "enabled": true } }
+{
+  "plugins": {
+    "allow": ["agent-status"],
+    "entries": {
+      "agent-status": { "enabled": true }
+    }
+  }
 }
 ```
 
 Restart OpenClaw, then test:
+
 ```bash
 curl http://localhost:18789/v1/agents/status \
   -H "Authorization: Bearer <your-token>"
 ```
 
+## Configuration
+
+Thresholds can be tuned in `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "agent-status": {
+        "enabled": true,
+        "config": {
+          "activeThresholdSeconds": 300,
+          "idleThresholdSeconds": 1800
+        }
+      }
+    }
+  }
+}
+```
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `activeThresholdSeconds` | `300` | Seconds within which an agent is considered `active` (default: 5 min) |
+| `idleThresholdSeconds` | `1800` | Seconds after which an agent becomes `stale` (default: 30 min) |
+
 ## Remote access
 
-Pair with [openclaw-network-setup](https://github.com/sinkers/openclaw-network-setup) (Tailscale or Cloudflare Tunnel) to query from anywhere:
+Pair with [Tailscale](https://tailscale.com) or a Cloudflare Tunnel to query from anywhere:
 
 ```bash
 curl https://your-openclaw.example.com/v1/agents/status \
   -H "Authorization: Bearer <your-token>"
 ```
+
+## How it works
+
+- Agent list is read from `api.config.agents.list` — always reflects live `openclaw.json`
+- Last active time comes from the session store (`~/.openclaw/agents/<id>/sessions/sessions.json`)
+- The most recently updated session is used — whether it's Telegram, Discord, webchat, or heartbeat
+- `current_task` scans the tail of the session transcript (JSONL) for the last assistant text reply
+- File reads use a seek-to-end approach so large transcripts don't cause slowness
+
+## Requirements
+
+- OpenClaw gateway with HTTP endpoints enabled
+- `gateway.http.endpoints.chatCompletions.enabled: true` (or equivalent) in `openclaw.json`

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,283 @@
+/**
+ * agent-status — OpenClaw plugin
+ *
+ * Registers GET /v1/agents/status on the OpenClaw gateway.
+ * Returns live status for all configured agents: last activity time, status
+ * classification, and a snippet of what they were last doing.
+ *
+ * Endpoints:
+ *   GET /v1/agents/status             — all agents
+ *   GET /v1/agents/status/:agentId    — single agent (404 if not found)
+ *
+ * Response shape:
+ *   { "object": "list", "data": [{ "id": "...", "name": "...", "status": "active|idle|stale", ... }] }
+ *
+ * Status thresholds (configurable via openclaw.json plugin config):
+ *   activeThresholdSeconds  — default 300   (5 min)
+ *   idleThresholdSeconds    — default 1800  (30 min)
+ */
+
+import type { IncomingMessage, ServerResponse } from "http";
+import { readFileSync, openSync, readSync, fstatSync, closeSync } from "fs";
+import { join } from "path";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface AgentConfig {
+  id: string;
+  name?: string;
+  identity?: { name?: string };
+}
+
+interface SessionEntry {
+  sessionId?: string;
+  updatedAt?: number;
+  sessionFile?: string;
+}
+
+interface SessionStore {
+  [sessionKey: string]: SessionEntry;
+}
+
+interface AgentStatusEntry {
+  id: string;
+  name: string;
+  status: "active" | "idle" | "stale";
+  last_active: string | null;
+  last_active_ago_seconds: number | null;
+  current_task: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function getAgentDisplayName(agent: AgentConfig): string {
+  // Priority: identity.name > capitalize(name) > capitalize(id)
+  return (
+    agent.identity?.name ??
+    (agent.name ? capitalize(agent.name) : capitalize(agent.id))
+  );
+}
+
+/**
+ * Read the last `maxBytes` of a file efficiently using a seek + read.
+ * Returns the content as a string. Safe to call on missing/empty files.
+ */
+function readFileTail(filePath: string, maxBytes = 16384): string {
+  let fd: number | null = null;
+  try {
+    fd = openSync(filePath, "r");
+    const stat = fstatSync(fd);
+    const fileSize = stat.size;
+    if (fileSize === 0) return "";
+
+    const readBytes = Math.min(maxBytes, fileSize);
+    const offset = fileSize - readBytes;
+    const buf = Buffer.allocUnsafe(readBytes);
+    readSync(fd, buf, 0, readBytes, offset);
+    return buf.toString("utf8");
+  } catch {
+    return "";
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Scan a JSONL transcript tail and return the last assistant text message
+ * (truncated to 100 chars), or null if none found.
+ */
+function getLastAssistantText(sessionFile: string): string | null {
+  const tail = readFileTail(sessionFile, 16384);
+  if (!tail) return null;
+
+  // Split into lines — first line may be partial; skip it
+  const lines = tail.split("\n");
+  const safeLines = tail.startsWith("{") ? lines : lines.slice(1);
+
+  for (let i = safeLines.length - 1; i >= 0; i--) {
+    const line = safeLines[i].trim();
+    if (!line) continue;
+    try {
+      const entry = JSON.parse(line) as {
+        type?: string;
+        message?: {
+          role?: string;
+          content?: Array<{ type?: string; text?: string }>;
+        };
+      };
+      if (entry.type !== "message") continue;
+      if (entry.message?.role !== "assistant") continue;
+
+      const content = entry.message.content;
+      if (!Array.isArray(content)) continue;
+
+      const textBlock = content.find((c) => c.type === "text" && c.text);
+      if (!textBlock?.text) continue;
+
+      const text = textBlock.text.trim();
+      if (!text) continue;
+
+      return text.length > 100 ? text.slice(0, 100) + "…" : text;
+    } catch {
+      // Malformed line — skip
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read the agent's session store and return the most recently active session.
+ */
+function getMostRecentSession(
+  stateDir: string,
+  agentId: string
+): { updatedAt: number; sessionFile: string | undefined } | null {
+  const sessionsPath = join(stateDir, "agents", agentId, "sessions", "sessions.json");
+
+  let store: SessionStore;
+  try {
+    const raw = readFileSync(sessionsPath, "utf8");
+    store = JSON.parse(raw) as SessionStore;
+  } catch {
+    return null;
+  }
+
+  let bestUpdatedAt = 0;
+  let bestSessionFile: string | undefined;
+
+  for (const entry of Object.values(store)) {
+    if (typeof entry.updatedAt === "number" && entry.updatedAt > bestUpdatedAt) {
+      bestUpdatedAt = entry.updatedAt;
+      bestSessionFile = entry.sessionFile;
+    }
+  }
+
+  return bestUpdatedAt > 0
+    ? { updatedAt: bestUpdatedAt, sessionFile: bestSessionFile }
+    : null;
+}
+
+// ─── Plugin ───────────────────────────────────────────────────────────────────
+
+export default function register(api: any) {
+  // Configurable thresholds (seconds)
+  const activeThresholdSeconds: number =
+    api.pluginConfig?.activeThresholdSeconds ?? 300;   // 5 min
+  const idleThresholdSeconds: number =
+    api.pluginConfig?.idleThresholdSeconds ?? 1800;    // 30 min
+
+  function computeStatus(
+    updatedAtMs: number,
+    nowMs: number
+  ): "active" | "idle" | "stale" {
+    const agoSeconds = (nowMs - updatedAtMs) / 1000;
+    if (agoSeconds < activeThresholdSeconds) return "active";
+    if (agoSeconds < idleThresholdSeconds) return "idle";
+    return "stale";
+  }
+
+  function buildAgentStatus(agent: AgentConfig, stateDir: string): AgentStatusEntry {
+    const now = Date.now();
+    const session = getMostRecentSession(stateDir, agent.id);
+
+    if (!session) {
+      return {
+        id: agent.id,
+        name: getAgentDisplayName(agent),
+        status: "stale",
+        last_active: null,
+        last_active_ago_seconds: null,
+        current_task: null,
+      };
+    }
+
+    const agoSeconds = Math.floor((now - session.updatedAt) / 1000);
+    const status = computeStatus(session.updatedAt, now);
+    const current_task = session.sessionFile
+      ? getLastAssistantText(session.sessionFile)
+      : null;
+
+    return {
+      id: agent.id,
+      name: getAgentDisplayName(agent),
+      status,
+      last_active: new Date(session.updatedAt).toISOString(),
+      last_active_ago_seconds: agoSeconds,
+      current_task,
+    };
+  }
+
+  api.registerHttpRoute({
+    path: "/v1/agents/status",
+    auth: "gateway",
+    match: "prefix",
+    handler: async (req: IncomingMessage, res: ServerResponse) => {
+      // Only handle GET
+      if (req.method !== "GET") {
+        res.statusCode = 405;
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            error: { message: "Method not allowed", type: "invalid_request_error" },
+          })
+        );
+        return true;
+      }
+
+      const cfg = api.config;
+      const agentList: AgentConfig[] = cfg?.agents?.list ?? [{ id: "main" }];
+      const stateDir: string = api.runtime.state.resolveStateDir();
+
+      // Determine if this is a single-agent or list request
+      // /v1/agents/status        → list
+      // /v1/agents/status/       → list
+      // /v1/agents/status/elysse → single agent
+      const reqPath = (req.url ?? "").split("?")[0]; // strip query string
+      const basePath = "/v1/agents/status";
+      const suffix = reqPath
+        .slice(basePath.length)   // everything after the base
+        .replace(/^\/+/, "")      // strip leading slashes
+        .replace(/\/+$/, "");     // strip trailing slashes
+
+      if (suffix) {
+        // ── Single agent endpoint ──
+        const agentId = suffix;
+        const agent = agentList.find((a) => a.id === agentId);
+
+        if (!agent) {
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              error: {
+                message: `Agent '${agentId}' not found`,
+                type: "not_found_error",
+              },
+            })
+          );
+          return true;
+        }
+
+        const data = buildAgentStatus(agent, stateDir);
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(data));
+        return true;
+      }
+
+      // ── All agents endpoint ──
+      const data = agentList.map((agent) => buildAgentStatus(agent, stateDir));
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ object: "list", data }));
+      return true;
+    },
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import { readFileSync, openSync, readSync, fstatSync, closeSync } from "fs";
+import { readFile, open } from "fs/promises";
 import { join } from "path";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -37,6 +37,14 @@ interface SessionEntry {
 
 interface SessionStore {
   [sessionKey: string]: SessionEntry;
+}
+
+interface TranscriptEntry {
+  type?: string;
+  message?: {
+    role?: string;
+    content?: Array<{ type?: string; text?: string }>;
+  };
 }
 
 interface AgentStatusEntry {
@@ -66,25 +74,27 @@ function getAgentDisplayName(agent: AgentConfig): string {
  * Read the last `maxBytes` of a file efficiently using a seek + read.
  * Returns the content as a string. Safe to call on missing/empty files.
  */
-function readFileTail(filePath: string, maxBytes = 16384): string {
-  let fd: number | null = null;
+async function readFileTail(filePath: string, maxBytes = 16384): Promise<string> {
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
   try {
-    fd = openSync(filePath, "r");
-    const stat = fstatSync(fd);
+    fh = await open(filePath, "r");
+    const stat = await fh.stat();
     const fileSize = stat.size;
     if (fileSize === 0) return "";
 
     const readBytes = Math.min(maxBytes, fileSize);
     const offset = fileSize - readBytes;
     const buf = Buffer.allocUnsafe(readBytes);
-    readSync(fd, buf, 0, readBytes, offset);
+    await fh.read(buf, 0, readBytes, offset);
     return buf.toString("utf8");
-  } catch {
+  } catch (err) {
+    // File missing or unreadable — treat as empty
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.debug("[agent-status] readFileTail error:", (err as Error).message);
+    }
     return "";
   } finally {
-    if (fd !== null) {
-      try { closeSync(fd); } catch { /* ignore */ }
-    }
+    await fh?.close().catch(() => { /* ignore close errors */ });
   }
 }
 
@@ -92,8 +102,8 @@ function readFileTail(filePath: string, maxBytes = 16384): string {
  * Scan a JSONL transcript tail and return the last assistant text message
  * (truncated to 100 chars), or null if none found.
  */
-function getLastAssistantText(sessionFile: string): string | null {
-  const tail = readFileTail(sessionFile, 16384);
+async function getLastAssistantText(sessionFile: string): Promise<string | null> {
+  const tail = await readFileTail(sessionFile, 16384);
   if (!tail) return null;
 
   // Split into lines — first line may be partial; skip it
@@ -104,13 +114,7 @@ function getLastAssistantText(sessionFile: string): string | null {
     const line = safeLines[i].trim();
     if (!line) continue;
     try {
-      const entry = JSON.parse(line) as {
-        type?: string;
-        message?: {
-          role?: string;
-          content?: Array<{ type?: string; text?: string }>;
-        };
-      };
+      const entry = JSON.parse(line) as TranscriptEntry;
       if (entry.type !== "message") continue;
       if (entry.message?.role !== "assistant") continue;
 
@@ -135,17 +139,20 @@ function getLastAssistantText(sessionFile: string): string | null {
 /**
  * Read the agent's session store and return the most recently active session.
  */
-function getMostRecentSession(
+async function getMostRecentSession(
   stateDir: string,
   agentId: string
-): { updatedAt: number; sessionFile: string | undefined } | null {
+): Promise<{ updatedAt: number; sessionFile: string | undefined } | null> {
   const sessionsPath = join(stateDir, "agents", agentId, "sessions", "sessions.json");
 
   let store: SessionStore;
   try {
-    const raw = readFileSync(sessionsPath, "utf8");
+    const raw = await readFile(sessionsPath, "utf8");
     store = JSON.parse(raw) as SessionStore;
-  } catch {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.debug("[agent-status] sessions.json read error for", agentId, ":", (err as Error).message);
+    }
     return null;
   }
 
@@ -183,9 +190,9 @@ export default function register(api: any) {
     return "stale";
   }
 
-  function buildAgentStatus(agent: AgentConfig, stateDir: string): AgentStatusEntry {
+  async function buildAgentStatus(agent: AgentConfig, stateDir: string): Promise<AgentStatusEntry> {
     const now = Date.now();
-    const session = getMostRecentSession(stateDir, agent.id);
+    const session = await getMostRecentSession(stateDir, agent.id);
 
     if (!session) {
       return {
@@ -201,7 +208,7 @@ export default function register(api: any) {
     const agoSeconds = Math.floor((now - session.updatedAt) / 1000);
     const status = computeStatus(session.updatedAt, now);
     const current_task = session.sessionFile
-      ? getLastAssistantText(session.sessionFile)
+      ? await getLastAssistantText(session.sessionFile)
       : null;
 
     return {
@@ -265,7 +272,7 @@ export default function register(api: any) {
           return true;
         }
 
-        const data = buildAgentStatus(agent, stateDir);
+        const data = await buildAgentStatus(agent, stateDir);
         res.statusCode = 200;
         res.setHeader("Content-Type", "application/json");
         res.end(JSON.stringify(data));
@@ -273,7 +280,9 @@ export default function register(api: any) {
       }
 
       // ── All agents endpoint ──
-      const data = agentList.map((agent) => buildAgentStatus(agent, stateDir));
+      const data = await Promise.all(
+        agentList.map((agent) => buildAgentStatus(agent, stateDir))
+      );
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ object: "list", data }));

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,13 +1,19 @@
 {
-  "name": "agent-status",
-  "version": "0.1.0",
-  "description": "Exposes GET /v1/agents/status — live agent status for remote monitoring",
-  "author": "sinkers",
-  "endpoints": [
-    {
-      "method": "GET",
-      "path": "/v1/agents/status",
-      "handler": "handleAgentStatus"
+  "id": "agent-status",
+  "name": "Agent Status",
+  "description": "Exposes GET /v1/agents/status returning live agent status with last active time, status classification, and current task",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "activeThresholdSeconds": {
+        "type": "number",
+        "description": "Seconds since last activity to consider an agent 'active' (default: 300 = 5 minutes)"
+      },
+      "idleThresholdSeconds": {
+        "type": "number",
+        "description": "Seconds since last activity before an agent becomes 'stale' (default: 1800 = 30 minutes)"
+      }
     }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agent-status",
+  "version": "1.0.0",
+  "description": "OpenClaw plugin: exposes GET /v1/agents/status for live agent monitoring",
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
+}


### PR DESCRIPTION
Closes #1

## What this does

Builds the `agent-status` OpenClaw plugin from scratch, implementing both endpoints from the issue spec.

## Endpoints

- `GET /v1/agents/status` — returns all configured agents with status
- `GET /v1/agents/status/:agentId` — returns a single agent, 404 if not found

## Implementation approach

**Session data source:**  
Reads `~/.openclaw/agents/<id>/sessions/sessions.json` for each agent to find the most recently updated session entry (`updatedAt` field). This covers all session types (Telegram, Discord, webchat, heartbeat) — whatever was last active.

**current_task:**  
Uses a seek-to-end (`readFileTail`) approach to read the last 16KB of the session JSONL transcript, then scans backward for the last assistant message with text content. Truncated to 100 chars. Safe on large transcripts.

**Status thresholds:**  
Configurable via `openclaw.json` plugin config (`activeThresholdSeconds`, `idleThresholdSeconds`). Defaults: active <5min, idle <30min, stale >30min.

**Name resolution:**  
`identity.name` → `name` (capitalized) → `id` (capitalized).

## Tested locally

Smoke-tested against the live Pi session store — all 6 configured agents resolve with correct timestamps and status values.

## Files changed

| File | What |
|------|------|
| `index.ts` | Plugin implementation |
| `openclaw.plugin.json` | Updated to proper plugin manifest format with configSchema |
| `package.json` | New — required for OpenClaw extension loading |
| `README.md` | Full install + config + example output docs |

## Acceptance criteria check

- [x] `GET /v1/agents/status` returns all agents with status, last_active, last_active_ago_seconds, current_task  
- [x] Status values: active / idle / stale based on configurable thresholds  
- [x] `GET /v1/agents/status/:agentId` returns single agent or 404  
- [x] Works with remote access (no hardcoded addresses, uses gateway auth)  
- [x] Thresholds configurable in openclaw.json plugin config  
- [x] README updated with install instructions and example output